### PR TITLE
Composer: fixed version upper bounds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "repositories": [],
     "require": {
         "php": ">= 5.4.0",
-        "nette/nette": ">= 2.3.0",
+        "nette/nette": "~2.3.0",
         "kdyby/doctrine": "2.3.0",
         "symfony/yaml": "2.6.5",
         "symfony/validator": "2.6.5"


### PR DESCRIPTION
Current version for nette/nette is 2.4, on which the other dependencies cannot run yet. This is a quick fix only, since update to Nette 2.4 is always recommended.
